### PR TITLE
Correct parse args

### DIFF
--- a/examples/matching.clj
+++ b/examples/matching.clj
@@ -62,19 +62,19 @@
            (m/and (m/vector ?a _ _ ?b) (m/vector _ ?a _ ?b)) "Will not match - ?a cannot be 3 and 2"
            (m/and (m/vector ?a _ _ ?b) (m/vector _ _ ?a ?b)) (+ a b)))
 
-; Records (Binary tree exampl)
-(defrecord Tree [value left right])
+; Records (Binary tree example)
+(defrecord Tree [left value right])
 (defn insert [tree new-value]
   (m/match tree
-    nil (->Tree new-value nil nil)
-    (m/record Tree ?value ?left ?right) (if (< new-value value)
-                                          (->Tree value (insert left new-value) right)
-                                          (->Tree value left (insert right new-value)))))
+    nil (->Tree nil new-value nil)
+    (m/record Tree ?left ?value ?right) (if (< new-value value)
+                                          (->Tree (insert left new-value) value right)
+                                          (->Tree left value (insert right new-value)))))
 
 (defn tree->list [tree]
   (m/match tree
     nil nil
-    (m/record Tree ?value ?left ?right) (concat (tree->list left) (cons value (tree->list right)))))
+    (m/record Tree ?left ?value ?right) (concat (tree->list left) (cons value (tree->list right)))))
 
 (-> nil
     (insert 10)

--- a/examples/red_black_tree.clj
+++ b/examples/red_black_tree.clj
@@ -40,7 +40,6 @@
 (reduce insert-vec nil (range 20))
 
 ; With Records
-(require '[matchbox.matchers :as m])
 (defrecord Black [left value right])
 (defrecord Red [left value right])
 (defn balance-rec [tree]

--- a/examples/red_black_tree.clj
+++ b/examples/red_black_tree.clj
@@ -1,0 +1,86 @@
+(require '[matchbox.matchers :as m])
+
+; Based on http://www.leonardoborges.com/writings/2013/07/15/purely-functional-data-structures-in-clojure-red-black-trees/
+(defn balance-vec [tree]
+  (m/match tree
+    (m/or (m/vector :black (m/vector :red (m/vector :red ?a ?x ?b) ?y ?c) ?z ?d)
+          (m/vector :black (m/vector :red (m/vector :red ?a ?x ?b) ?y ?c) ?z ?d)
+          (m/vector :black (m/vector :red ?a ?x (m/vector :red ?b ?y ?c)) ?z ?d)
+          (m/vector :black ?a ?x (m/vector :red (m/vector :red ?b ?y ?c) ?z ?d))
+          (m/vector :black ?a ?x (m/vector :red ?b ?y (m/vector :red ?c ?z ?d))))
+    [:red [:black a x b] y [:black c z d]]
+
+    _ tree))
+
+(defn insert-vec [tree x]
+  (let [ins (fn ins [tree]
+              (m/match tree
+                nil [:red nil x nil]
+                (m/vector ?color ?a ?y ?b) (cond
+                                             (< x y) (balance-vec [color (ins a) y b])
+                                             (> x y) (balance-vec [color a y (ins b)])
+                                             :else tree)))
+        [_ a y b] (ins tree)]
+    [:black a y b]))
+
+(defn tree-vec->list [tree]
+  (m/match tree
+    nil nil
+    (m/vector _ ?left ?value ?right) (concat (tree-vec->list left) (cons value (tree-vec->list right)))))
+
+(-> nil
+    (insert-vec 10)
+    (insert-vec 25)
+    (insert-vec 1)
+    (insert-vec 4)
+    (insert-vec 40)
+    (insert-vec 12)
+    (insert-vec 21)
+    tree-vec->list)
+(reduce insert-vec nil (range 20))
+
+; With Records
+(require '[matchbox.matchers :as m])
+(defrecord Black [left value right])
+(defrecord Red [left value right])
+(defn balance-rec [tree]
+  (m/match tree
+    (m/or (m/record Black (m/record Red (m/record Red ?a ?x ?b) ?y ?c) ?z ?d)
+          (m/record Black (m/record Red (m/record Red ?a ?x ?b) ?y ?c) ?z ?d)
+          (m/record Black (m/record Red ?a ?x (m/record Red ?b ?y ?c)) ?z ?d)
+          (m/record Black ?a ?x (m/record Red (m/record Red ?b ?y ?c) ?z ?d))
+          (m/record Black ?a ?x (m/record Red ?b ?y (m/record Red ?c ?z ?d))))
+    (->Red (->Black a x b) y (->Black c z d))
+
+    _ tree))
+
+(defn insert-rec [tree x]
+  (let [ins (fn ins [tree]
+              (m/match tree
+                nil (->Red nil x nil)
+
+                (m/matches {:left ?a :value ?y :right ?b})
+                (cond
+                  (< x y) (balance-rec (assoc tree :left (ins a)))
+                  (> x y) (balance-rec (assoc tree :right (ins b)))
+                  :else tree)))
+        {:keys [left value right]} (ins tree)]
+    (->Black left value right)))
+
+(defn tree-rec->list [tree]
+  (m/match tree
+    nil nil
+
+    (m/matches {:left ?a :value ?y :right ?b})
+    (concat (tree-rec->list a) (cons y (tree-rec->list b)))))
+
+(-> nil
+    (insert-rec 10)
+    (insert-rec 25)
+    (insert-rec 1)
+    (insert-rec 4)
+    (insert-rec 40)
+    (insert-rec 12)
+    (insert-rec 21)
+    tree-rec->list)
+(reduce insert-rec nil (range 20))

--- a/src/matchbox/matchers.clj
+++ b/src/matchbox/matchers.clj
@@ -22,8 +22,20 @@
 (defn vector [ & rest]
   (fn [m] (when (vector? m) (check-elements m rest))))
 
+(defn coll [ & rest]
+  (fn [m] (when (coll? m) (check-elements m rest))))
+
 (defn matches [pattern]
   (fn [obj] [pattern obj]))
+
+(defn satisfies
+  ([pred-fn] (satisfies pred-fn '_))
+  ([pred-fn bind]
+   (fn [obj]
+     (try
+       (when-let [res (pred-fn obj)]
+         [bind res])
+       (catch Exception _)))))
 
 (defn- match-kv [elem [pattern-k pattern-v]]
   (let [[k v] elem
@@ -49,7 +61,7 @@
             (core/and m (recur forms submap acc)))
           [ls rs])))))
 
-(defn instance? [class]
+(defn instance [class]
   (fn [obj]
     (if (core/and (core/instance? java.lang.Class class)
                   (core/instance? class obj))

--- a/src/matchbox/utils/match.clj
+++ b/src/matchbox/utils/match.clj
@@ -24,8 +24,8 @@
 
 (defn- apply-inner [[ls rs]]
   (if (and (coll? ls) (coll? rs) (= (count ls) (count rs)))
-    (loop [[first-ls & rest-ls] ls
-           [first-rs & rest-rs] rs
+    (loop [[first-ls & rest-ls] (seq ls)
+           [first-rs & rest-rs] (seq rs)
            [acc-ls acc-rs] [[] []]]
 
       (when-let [inner-res (recurse-into-result first-ls first-rs)]

--- a/src/matchbox/utils/match.clj
+++ b/src/matchbox/utils/match.clj
@@ -12,6 +12,7 @@
                    args)]
     (cond
       (seq? args) (apply list parsed)
+      (map-entry? args) (vec parsed)
       :else (into (empty args) parsed))))
 
 (declare apply-match)

--- a/test/matchbox/matchers_test.clj
+++ b/test/matchbox/matchers_test.clj
@@ -118,5 +118,6 @@
 
   (fact "applies inner params and anon functions"
     (m/match '(30 40 50)
+      (m/matches {:a ?b}) :foo
       (m/satisfies #(some #{-1 -2} %) ?r) r
       (m/satisfies #(some #{3 4 50 40} %) ?r) r) => 40))

--- a/test/matchbox/matchers_test.clj
+++ b/test/matchbox/matchers_test.clj
@@ -27,32 +27,39 @@
   ((m/vector 1 '?foo 3) test-vec) => [[1 '?foo 3] [1 2 3]]
   ((m/vector 1 '& '?rest) test-vec) => [[1 '?rest] [1 '(2 3)]])
 
+(fact "Matching against any collection"
+  ((m/coll 1 2 3) '(1 2 3)) => match
+  ((m/coll 1 '?foo 3) test-vec) => (match-and-unify '?foo 2))
+
 (def test-map {:a 10, :b 20})
 (fact "Matching using unifier only"
   ((m/matches {:a '?a, '?b 20}) test-map) => [{:a '?a, '?b 20} {:a 10 :b 20}]
   ((m/matches {:a '?a, '?b 20}) test-vec) => [{:a '?a, '?b 20} [1 2 3]]
   ((m/matches [1 2 3]) test-vec) => [[1 2 3] [1 2 3]])
 
+(facts "Predicate matching with core functions"
+  ((m/satisfies even?) 10) => match
+  ((m/satisfies even? '?result) 10) => (match-and-unify '?result true)
+  ((m/satisfies even? '?result) "FOO") => dont-match)
+
 (facts "Matching against maps"
   (fact "simple matches"
-    ((m/map :a '?a) test-vec) => nil
-    ((m/map) test-map) => [[] []]
-    ((m/map :a '?a) test-map) => [[[[] ['?a]]] [[[] [10]]]]
-    ((m/map '?a 20) test-map) => [[[['?a] []]] [[[:b] []]]]
-    ((m/map '?a '?b) test-map) => [[[['?a] ['?b]]] [[[:a] [10]]]]
-    ((m/map '?a 20 '?b 10) test-map)
-    => [[[['?a] []] [['?b] []]] [[[:b] []] [[:a] []]]])
+    ((m/map :a '?a) test-vec) => dont-match
+    ((m/map) test-map) => match
+    ((m/map :a '?a) test-map) => (match-and-unify '?a 10)
+    ((m/map '?a 20) test-map) => (match-and-unify '?a :b)
+    ((m/map '?a '?b) test-map) => (match-and-unify '?a :a '?b 10)
+    ((m/map '?a 20 '?b 10) test-map) => (match-and-unify '?a :b '?b :a))
 
   (fact "composite matches"
-    ((m/map :a (m/list)) test-map) => nil
-    ((m/map :a 10 :b (m/list)) test-map) => nil
-    ((m/map '?a (m/list '& '_)) {:a 10, :b 20, :c '(1 2 3)})
-    => [[[['?a] []]] [[[:c] []]]]))
+    ((m/map :a (m/list)) test-map) => dont-match
+    ((m/map :a 10 :b (m/list)) test-map) => dont-match
+    ((m/map '?a (m/list '& '_)) {:a 10, :b 20, :c '(1 2 3)}) => (match-and-unify '?a :c)))
 
 (fact "Matching instances of some element"
-  ((m/instance? clojure.lang.PersistentList) '(1 2) ) => []
-  ((m/instance? clojure.lang.PersistentList) [1 2] ) => dont-match
-  ((m/instance? 10) [1 2] ) => dont-match)
+  ((m/instance clojure.lang.PersistentList) '(1 2) ) => []
+  ((m/instance clojure.lang.PersistentList) [1 2] ) => dont-match
+  ((m/instance 10) [1 2] ) => dont-match)
 
 (defrecord Example [a b c])
 (defrecord Example2 [a b c])
@@ -107,4 +114,9 @@
 
     (m/match '(1 2 (2 3) 4)
       (m/list ?a 2 (m/list ?a ?a) 4) :foo
-      (m/list 1 ?a (m/list ?a ?b) ?c) (+ a b c)) => 9))
+      (m/list 1 ?a (m/list ?a ?b) ?c) (+ a b c)) => 9)
+
+  (fact "applies inner params and anon functions"
+    (m/match '(30 40 50)
+      (m/satisfies #(some #{-1 -2} %) ?r) r
+      (m/satisfies #(some #{3 4 50 40} %) ?r) r) => 40))

--- a/test/matchbox/utils/match_test.clj
+++ b/test/matchbox/utils/match_test.clj
@@ -62,6 +62,14 @@
           (let [~'a (~''?a ~'foo)
                 ~'b (~''?b ~'foo)]
             (~'+ ~'a ~'b))
+          :bar)
+
+    (utils/wrap-let 'test-list '(m/match {:a ?a :b ?b}) '(+ a b) ':bar)
+    => `(if-let [~'foo (utils/match-and-unify ~'test-list (~'m/match {:a ~''?a
+                                                                      :b ~''?b}))]
+          (let [~'a (~''?a ~'foo)
+                ~'b (~''?b ~'foo)]
+            (~'+ ~'a ~'b))
           :bar)))
 
 (facts "pattern matching without macros"

--- a/test/matchbox/utils/match_test.clj
+++ b/test/matchbox/utils/match_test.clj
@@ -8,7 +8,8 @@
 (fact "parses args correctly from matchers"
   (utils/parse-args '(m/list ?arg _ 10 foo)) => '(m/list '?arg '_ 10 foo)
   (utils/parse-args '(m/list _ & _foo)) => '(m/list '_ '& _foo)
-  (utils/parse-args '(m/list ?arg _ (m/list ?b) foo)) => '(m/list '?arg '_ (m/list '?b) foo))
+  (utils/parse-args '(m/list ?arg _ (m/list ?b) foo)) => '(m/list '?arg '_ (m/list '?b) foo)
+  (utils/parse-args '(m/list [?b _ #{_ ?a}])) => '(m/list ['?b '_ #{'_ '?a}]))
 
 (def test-list (list 1 2 3))
 (facts "parses match args correcly"
@@ -37,6 +38,12 @@
   (fact "unwraps code if there are no sexps on match side"
     (utils/wrap-let 10 10 :foo :bar)
     => `(if-let [~'foo (utils/match-and-unify 10 10)]
+         :foo
+         :bar))
+
+  (fact "unwraps code if matcher is a set"
+    (utils/wrap-let 10 #{1 10} :foo :bar)
+    => `(if-let [~'foo (utils/match-and-unify 10 #{1 10})]
          :foo
          :bar))
 


### PR DESCRIPTION
`coll`s can be maps and sets, and they don't support the kind of parameter deconstruction we do with vectors and lists...
